### PR TITLE
Remove final da Classe Rede.php

### DIFF
--- a/Model/Rede.php
+++ b/Model/Rede.php
@@ -8,7 +8,7 @@ namespace Rede\Adquirencia\Model;
 /**
  * Class ConfigProvider
  */
-final class Rede extends \Magento\Payment\Model\Method\Cc
+class Rede extends \Magento\Payment\Model\Method\Cc
 {
     const METHOD_CODE = 'rede';
 


### PR DESCRIPTION
Erro ao compilar módulo , causado pela classe Rede por estar instanciada como final.