### PR TITLE
Armazenando apenas os 4 últimos dígitos do cartão.

### DIFF
--- a/Gateway/Response/CardDetailsHandler.php
+++ b/Gateway/Response/CardDetailsHandler.php
@@ -51,7 +51,7 @@ class CardDetailsHandler implements HandlerInterface
          */
         $response_obj = $this->subjectReader->readTransaction($response);
 
-        $payment->setCcLast4($response_obj->getCardNumber());
+        $payment->setCcLast4(substr($response_obj->getCardNumber(), -4));
         $payment->setCcExpMonth($response_obj->getExpirationMonth());
         $payment->setCcExpYear($response_obj->getExpirationYear());
         $payment->setCcType($response_obj->getCardBin());
@@ -65,3 +65,4 @@ class CardDetailsHandler implements HandlerInterface
     }
 
 }
+


### PR DESCRIPTION
Atualmente o módulo está armazenando todos os dígitos do número do cartão na tabela sales_order_payment no campo cc_last_4.

Realizei testes no ambiente (Environment) de teste e no de produção (realizando compras reais).
